### PR TITLE
docs: add banner asking for use cases at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 <h5 align="center">
   <br>
+  <a href="https://github.com/asyncapi/event-gateway/issues/new?assignees=&labels=use+case&template=use_case.md&title=%5BUSECASE%5D+">
+    <img src="https://dummyimage.com/1000x80/0e9f6f/ffffff.png&text=We+are+looking+for+use+cases!+Please+share+yours+by+clicking+here" alt="Share your use case with us">
+  </a>
+  <br>
+</h5>
+
+<h5 align="center">
+  <br>
   <a href="https://www.asyncapi.org"><img src="https://github.com/asyncapi/parser-nodejs/raw/master/assets/logo.png" alt="AsyncAPI logo" width="200"></a>
   <br>
   AsyncAPI Event Gateway


### PR DESCRIPTION
**Description**

This PR adds a text banner at the top of the README file asking for use cases. The banner is generated through https://dummyimage.com.
This is how it looks:

![image](https://user-images.githubusercontent.com/1083296/110793118-8ee32480-8274-11eb-9017-dc3fd703f343.png)

