### PR TITLE
chore: extract Kafka proxy logic to its own package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pierrec/lz4 v2.6.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/xdg/scram v1.0.3 // indirect
 	github.com/xdg/stringprep v1.0.3 // indirect
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect

--- a/kafka/protocol/control_record.go
+++ b/kafka/protocol/control_record.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/crc32_field.go
+++ b/kafka/protocol/crc32_field.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/decoder.go
+++ b/kafka/protocol/decoder.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/decompress.go
+++ b/kafka/protocol/decompress.go
@@ -1,4 +1,4 @@
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/key.go
+++ b/kafka/protocol/key.go
@@ -1,4 +1,4 @@
-package kafka
+package protocol
 
 // Kafka request API Keys. See https://kafka.apache.org/protocol#protocol_api_keys.
 const (

--- a/kafka/protocol/length_field.go
+++ b/kafka/protocol/length_field.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/message.go
+++ b/kafka/protocol/message.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/message_set.go
+++ b/kafka/protocol/message_set.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/produce_request.go
+++ b/kafka/protocol/produce_request.go
@@ -1,4 +1,4 @@
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/record.go
+++ b/kafka/protocol/record.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/record_batch.go
+++ b/kafka/protocol/record_batch.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/records.go
+++ b/kafka/protocol/records.go
@@ -1,4 +1,4 @@
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/timestamp.go
+++ b/kafka/protocol/timestamp.go
@@ -1,4 +1,4 @@
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/protocol/zstd.go
+++ b/kafka/protocol/zstd.go
@@ -1,5 +1,5 @@
 //nolint
-package kafka
+package protocol
 
 // The types on this file have been copied from https://github.com/Shopify/sarama and are used for decoding requests.
 // As the decoder/encoder interfaces in Sarama project are not public, there is no way of reusing.

--- a/kafka/proxy.go
+++ b/kafka/proxy.go
@@ -1,0 +1,110 @@
+package kafka
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/asyncapi/event-gateway/kafka/protocol"
+	"github.com/asyncapi/event-gateway/proxy"
+	server "github.com/grepplabs/kafka-proxy/cmd/kafka-proxy"
+	kafkaproxy "github.com/grepplabs/kafka-proxy/proxy"
+	kafkaprotocol "github.com/grepplabs/kafka-proxy/proxy/protocol"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ProxyConfig holds the configuration for the Kafka Proxy.
+type ProxyConfig struct {
+	BrokersMapping     []string
+	DialAddressMapping []string
+	ExtraConfig        []string
+	Debug              bool
+}
+
+// NewProxy creates a new Kafka Proxy based on a given configuration.
+func NewProxy(c ProxyConfig) (proxy.Proxy, error) {
+	// Yeah, not a good practice at all but I guess it's fine for now.
+	kafkaproxy.ActualDefaultRequestHandler.RequestKeyHandlers.Set(protocol.RequestAPIKeyProduce, &requestKeyHandler{})
+
+	if c.BrokersMapping == nil {
+		return nil, errors.New("Brokers mapping is required")
+	}
+
+	if c.Debug {
+		_ = server.Server.Flags().Set("log-level", "debug")
+	}
+
+	for _, v := range c.ExtraConfig {
+		f := strings.Split(v, "=")
+		_ = server.Server.Flags().Set(f[0], f[1])
+	}
+
+	for _, v := range c.BrokersMapping {
+		_ = server.Server.Flags().Set("bootstrap-server-mapping", v)
+	}
+
+	for _, v := range c.DialAddressMapping {
+		_ = server.Server.Flags().Set("dial-address-mapping", v)
+	}
+
+	return func(_ context.Context) error {
+		return server.Server.Execute()
+	}, nil
+}
+
+type requestKeyHandler struct{}
+
+func (r *requestKeyHandler) Handle(requestKeyVersion *kafkaprotocol.RequestKeyVersion, src io.Reader, ctx *kafkaproxy.RequestsLoopContext, bufferRead *bytes.Buffer) (shouldReply bool, err error) {
+	if requestKeyVersion.ApiKey != protocol.RequestAPIKeyProduce {
+		return true, nil
+	}
+
+	shouldReply, err = kafkaproxy.DefaultProduceKeyHandlerFunc(requestKeyVersion, src, ctx, bufferRead)
+	if err != nil {
+		return
+	}
+
+	msg := make([]byte, int64(requestKeyVersion.Length-int32(4+len(bufferRead.Bytes()))))
+	if _, err = io.ReadFull(io.TeeReader(src, bufferRead), msg); err != nil {
+		return
+	}
+
+	var req protocol.ProduceRequest
+	if err = protocol.VersionedDecode(msg, &req, requestKeyVersion.ApiVersion); err != nil {
+		logrus.Errorln(errors.Wrap(err, "error decoding ProduceRequest"))
+
+		// Do not return an error but log it.
+		return shouldReply, nil
+	}
+
+	for _, r := range req.Records {
+		for _, s := range r {
+			if s.RecordBatch != nil {
+				for _, r := range s.RecordBatch.Records {
+					if !isValid(r.Value) {
+						logrus.Errorln("Message is not valid")
+					} else {
+						logrus.Debugln("Message is valid")
+					}
+				}
+			}
+			if s.MsgSet != nil {
+				for _, mb := range s.MsgSet.Messages {
+					if !isValid(mb.Msg.Value) {
+						logrus.Errorln("Message is not valid")
+					} else {
+						logrus.Debugln("Message is valid")
+					}
+				}
+			}
+		}
+	}
+
+	return shouldReply, nil
+}
+
+func isValid(msg []byte) bool {
+	return string(msg) != "invalid message"
+}

--- a/kafka/proxy_test.go
+++ b/kafka/proxy_test.go
@@ -1,0 +1,92 @@
+package kafka
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/asyncapi/event-gateway/proxy"
+	kafkaproxy "github.com/grepplabs/kafka-proxy/proxy"
+	kafkaprotocol "github.com/grepplabs/kafka-proxy/proxy/protocol"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKafka(t *testing.T) {
+	tests := []struct {
+		name        string
+		c           ProxyConfig
+		expectedErr error
+	}{
+		{
+			name: "Proxy is created when config is valid",
+			c: ProxyConfig{
+				BrokersMapping: []string{"localhost:9092, localhost:28002"},
+			},
+		},
+		{
+			name:        "Proxy creation errors when config is invalid",
+			c:           ProxyConfig{},
+			expectedErr: errors.New("Brokers mapping is required"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := NewProxy(test.c)
+			if test.expectedErr != nil {
+				assert.EqualError(t, err, test.expectedErr.Error())
+				assert.Nil(t, p)
+			} else {
+				assert.NoError(t, err)
+				assert.IsType(t, (proxy.Proxy)(nil), p)
+			}
+		})
+	}
+}
+
+func TestRequestKeyHandler_Handle(t *testing.T) {
+	tests := []struct {
+		name              string
+		request           []byte
+		shouldReply       bool
+		apiKey            int16
+		shouldSkipRequest bool
+	}{
+		{
+			name:        "Valid message",
+			request:     []byte{0, 0, 0, 7, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}, // payload: 'valid message'
+			shouldReply: true,
+		},
+		{
+			name:        "Invalid message",
+			request:     []byte{0, 0, 0, 8, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}, // payload: 'invalid message'
+			shouldReply: true,
+		},
+		{
+			name:              "Other Requests (different than Produce type) are skipped",
+			request:           []byte{0, 0, 0, 1}, // fake payload that should not be read.
+			apiKey:            int16(42),
+			shouldReply:       true,
+			shouldSkipRequest: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kv := &kafkaprotocol.RequestKeyVersion{
+				ApiKey: test.apiKey,                  // default is 0, which is a Produce Request
+				Length: int32(len(test.request)) + 4, // 4 bytes are ApiKey + Version located in all request headers (already read by the time of validating the msg).
+			}
+
+			readBytes := bytes.NewBuffer(nil)
+			var h requestKeyHandler
+			shouldReply, err := h.Handle(kv, bytes.NewReader(test.request), &kafkaproxy.RequestsLoopContext{}, readBytes)
+			assert.NoError(t, err)
+			assert.Equal(t, test.shouldReply, shouldReply)
+
+			if test.shouldSkipRequest {
+				assert.Empty(t, readBytes.Bytes()) // Payload is never read.
+			} else {
+				assert.Equal(t, readBytes.Len(), len(test.request))
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	proxyConfig := kafka.ProxyConfig{
+	kafkaProxyConfig := kafka.ProxyConfig{
 		BrokersMapping:     c.KafkaProxyBrokersMapping.values,
 		DialAddressMapping: c.KafkaProxyBrokersDialMapping.values,
 		ExtraConfig:        c.KafkaProxyExtraFlags.values,

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 		Debug:              c.Debug,
 	}
 
-	kafkaProxy, err := kafka.NewProxy(proxyConfig)
+	kafkaProxy, err := kafka.NewProxy(kafkaProxyConfig)
 	if err != nil {
 		logrus.Fatalln(err)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,6 @@
+package proxy
+
+import "context"
+
+// Proxy represents an event-gateway proxy.
+type Proxy func(ctx context.Context) error


### PR DESCRIPTION
**Description**

This PR moves all the logic related to the Kafka proxy creation that was previously in the `main.go` file to it's own package.
It also adds a test for the message validation logic.
It also adds a new func that will implement all proxies (on its own package called `proxy`).

This change is useful for the next PR's which will use it.