### PR TITLE
fix: fix kafka proxy tests

### DIFF
--- a/kafka/proxy.go
+++ b/kafka/proxy.go
@@ -66,14 +66,14 @@ func (r *requestKeyHandler) Handle(requestKeyVersion *kafkaprotocol.RequestKeyVe
 		return
 	}
 
-	msg := make([]byte, int64(requestKeyVersion.Length-int32(4+len(bufferRead.Bytes()))))
+	msg := make([]byte, int64(requestKeyVersion.Length-int32(4+bufferRead.Len())))
 	if _, err = io.ReadFull(io.TeeReader(src, bufferRead), msg); err != nil {
 		return
 	}
-
 	var req protocol.ProduceRequest
 	if err = protocol.VersionedDecode(msg, &req, requestKeyVersion.ApiVersion); err != nil {
 		logrus.Errorln(errors.Wrap(err, "error decoding ProduceRequest"))
+		// TODO notify error to a given notifier
 
 		// Do not return an error but log it.
 		return shouldReply, nil
@@ -84,7 +84,7 @@ func (r *requestKeyHandler) Handle(requestKeyVersion *kafkaprotocol.RequestKeyVe
 			if s.RecordBatch != nil {
 				for _, r := range s.RecordBatch.Records {
 					if !isValid(r.Value) {
-						logrus.Errorln("Message is not valid")
+						logrus.Debugln("Message is not valid")
 					} else {
 						logrus.Debugln("Message is valid")
 					}
@@ -93,7 +93,7 @@ func (r *requestKeyHandler) Handle(requestKeyVersion *kafkaprotocol.RequestKeyVe
 			if s.MsgSet != nil {
 				for _, mb := range s.MsgSet.Messages {
 					if !isValid(mb.Msg.Value) {
-						logrus.Errorln("Message is not valid")
+						logrus.Debugln("Message is not valid")
 					} else {
 						logrus.Debugln("Message is valid")
 					}

--- a/kafka/proxy_test.go
+++ b/kafka/proxy_test.go
@@ -8,8 +8,18 @@ import (
 	kafkaproxy "github.com/grepplabs/kafka-proxy/proxy"
 	kafkaprotocol "github.com/grepplabs/kafka-proxy/proxy/protocol"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
+
+// Note: Taking V8 as random version.
+// correlation_id: 0, 0, 0, 6
+// client_id_size: 0, 16
+// client_id: 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114
+// transactional_id_size: 255, 255
+// acks: 0, 1
+var produceRequestV8Headers = []byte{0, 0, 0, 6, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}
 
 func TestNewKafka(t *testing.T) {
 	tests := []struct {
@@ -53,12 +63,12 @@ func TestRequestKeyHandler_Handle(t *testing.T) {
 	}{
 		{
 			name:        "Valid message",
-			request:     []byte{0, 0, 0, 7, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}, // payload: 'valid message'
+			request:     []byte{0, 0, 5, 220, 0, 0, 0, 1, 0, 4, 100, 101, 109, 111, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 255, 255, 255, 255, 2, 42, 190, 231, 201, 0, 0, 0, 0, 0, 0, 0, 0, 1, 122, 129, 58, 51, 194, 0, 0, 1, 122, 129, 58, 51, 194, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 38, 0, 0, 0, 1, 26, 118, 97, 108, 105, 100, 32, 109, 101, 115, 115, 97, 103, 101, 0}, // payload: 'valid message'
 			shouldReply: true,
 		},
 		{
 			name:        "Invalid message",
-			request:     []byte{0, 0, 0, 8, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}, // payload: 'invalid message'
+			request:     []byte{0, 0, 5, 220, 0, 0, 0, 1, 0, 4, 100, 101, 109, 111, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 255, 255, 255, 255, 2, 122, 198, 121, 91, 0, 0, 0, 0, 0, 0, 0, 0, 1, 122, 129, 58, 129, 47, 0, 0, 1, 122, 129, 58, 129, 47, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 42, 0, 0, 0, 1, 30, 105, 110, 118, 97, 108, 105, 100, 32, 109, 101, 115, 115, 97, 103, 101, 0}, // payload: 'invalid message'
 			shouldReply: true,
 		},
 		{
@@ -71,13 +81,17 @@ func TestRequestKeyHandler_Handle(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			log := logrustest.NewGlobal()
+			test.request = append(produceRequestV8Headers, test.request...) // This appends the Produce Request headers which we don't care for this test.
 			kv := &kafkaprotocol.RequestKeyVersion{
-				ApiKey: test.apiKey,                  // default is 0, which is a Produce Request
-				Length: int32(len(test.request)) + 4, // 4 bytes are ApiKey + Version located in all request headers (already read by the time of validating the msg).
+				ApiVersion: 8,                            // All test data was grabbed from a Produce Request version 8.
+				ApiKey:     test.apiKey,                  // default is 0, which is a Produce Request
+				Length:     int32(len(test.request) + 4), // 4 bytes are ApiKey + Version located in all request headers (already read by the time of validating the msg).
 			}
 
 			readBytes := bytes.NewBuffer(nil)
 			var h requestKeyHandler
+
 			shouldReply, err := h.Handle(kv, bytes.NewReader(test.request), &kafkaproxy.RequestsLoopContext{}, readBytes)
 			assert.NoError(t, err)
 			assert.Equal(t, test.shouldReply, shouldReply)
@@ -86,6 +100,10 @@ func TestRequestKeyHandler_Handle(t *testing.T) {
 				assert.Empty(t, readBytes.Bytes()) // Payload is never read.
 			} else {
 				assert.Equal(t, readBytes.Len(), len(test.request))
+			}
+
+			for _, l := range log.AllEntries() {
+				assert.NotEqualf(t, l.Level, logrus.ErrorLevel, "%q logged error unexpected", l.Message) // We don't have a notification mechanism for errors yet
 			}
 		})
 	}

--- a/kafka/proxy_test.go
+++ b/kafka/proxy_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Note: Taking V8 as random version.
-// correlation_id: 0, 0, 0, 6
-// client_id_size: 0, 16
-// client_id: 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114
-// transactional_id_size: 255, 255
-// acks: 0, 1
-var produceRequestV8Headers = []byte{0, 0, 0, 6, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1}
-
 func TestNewKafka(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -112,10 +104,17 @@ func TestRequestKeyHandler_Handle(t *testing.T) {
 
 //nolint:funlen
 func generateProduceRequestV8(payload string) []byte {
+	// Note: Taking V8 as random version.
 	buf := bytes.NewBuffer(nil)
 
 	// Request headers
-	buf.Write(produceRequestV8Headers)
+	//
+	// correlation_id: 0, 0, 0, 6
+	// client_id_size: 0, 16
+	// client_id: 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114
+	// transactional_id_size: 255, 255
+	// acks: 0, 1
+	buf.Write([]byte{0, 0, 0, 6, 0, 16, 99, 111, 110, 115, 111, 108, 101, 45, 112, 114, 111, 100, 117, 99, 101, 114, 255, 255, 0, 1})
 
 	// timeout: 0, 0, 5, 200
 	// topics count: 0, 0, 0, 1


### PR DESCRIPTION
**Description**

Tests were failing silently as no error happens when decoding goes wrong. This is on purpose so we do not break the basic proxy functionality (clients can still communicate to the brokers). 

This change fixes the payloads in the tests and changes log levels to rely by now on them, so tests will fail if decoding goes wrong. 
