### PR TITLE
feat: add message validation based on schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,3 +45,9 @@ linters-settings:
   forbidigo:
     forbid:
       - fmt.Print.* # usually just used for debugging purpose
+
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - funlen

--- a/asyncapi/document.go
+++ b/asyncapi/document.go
@@ -80,14 +80,22 @@ type Message interface {
 	Payload() Schema
 }
 
+// FalsifiableSchema is a variadic type used for some Schema fields.
+// For example, additionalProperties value can be either `false` or a Schema.
+type FalsifiableSchema interface {
+	IsFalse() bool
+	IsSchema() bool
+	Schema() Schema
+}
+
 // Schema is an object that allows the definition of input and output data types.
 // These types can be objects, but also primitives and arrays.
 // This object is a superset of the JSON Schema Specification Draft 07.
 type Schema interface {
 	Extendable
 	ID() string
-	AdditionalItems() Schema
-	AdditionalProperties() Schema // TODO (boolean | Schema)
+	AdditionalItems() FalsifiableSchema
+	AdditionalProperties() FalsifiableSchema // TODO (boolean | Schema)
 	AllOf() []Schema
 	AnyOf() []Schema
 	CircularProps() []string
@@ -121,7 +129,7 @@ type Schema interface {
 	MinProperties() *float64
 	MultipleOf() *float64
 	Not() Schema
-	OneOf() Schema
+	OneOf() []Schema
 	Pattern() string
 	PatternProperties() map[string]Schema
 	Properties() map[string]Schema

--- a/asyncapi/document.go
+++ b/asyncapi/document.go
@@ -128,7 +128,7 @@ type Schema interface {
 	Property(name string) Schema
 	PropertyNames() Schema
 	ReadOnly() bool
-	Required() string // TODO string[]
+	Required() []string
 	Then() Schema
 	Title() string
 	Type() []string // TODO // string | string[]

--- a/asyncapi/v2/decode_test.go
+++ b/asyncapi/v2/decode_test.go
@@ -55,7 +55,7 @@ func TestDecodeFromFile(t *testing.T) {
 	}
 }
 
-//nolint:misspell,funlen
+//nolint:misspell
 func TestDecodeFromPlainText(t *testing.T) {
 	raw := []byte(`
 asyncapi: '2.0.0'

--- a/asyncapi/v2/v2.go
+++ b/asyncapi/v2/v2.go
@@ -449,7 +449,7 @@ type Schema struct {
 	RequiredField             []string          `mapstructure:"required" json:"required,omitempty"`
 	ThenField                 *Schema           `mapstructure:"then" json:"then,omitempty"`
 	TitleField                string            `mapstructure:"title" json:"title,omitempty"`
-	TypeField                 interface{}       `mapstructure:"type" json:"type"` // string | []string
+	TypeField                 interface{}       `mapstructure:"type" json:"type,omitempty"` // string | []string
 	UniqueItemsField          bool              `mapstructure:"uniqueItems" json:"uniqueItems,omitempty"`
 	WriteOnlyField            bool              `mapstructure:"writeOnly" json:"writeOnly,omitempty"`
 

--- a/asyncapi/v2/v2.go
+++ b/asyncapi/v2/v2.go
@@ -168,6 +168,13 @@ func (d Document) filterOperations(filter func(operation asyncapi.Operation) boo
 	return operations
 }
 
+// NewChannel creates a new Channel. Useful for testing.
+func NewChannel(path string) *Channel {
+	return &Channel{
+		PathField: path,
+	}
+}
+
 type Channel struct {
 	Extendable
 	Describable     `mapstructure:",squash"`
@@ -250,10 +257,20 @@ type SubscribeOperation struct {
 	Operation
 }
 
+// NewSubscribeOperation creates a new SubscribeOperation. Useful for testing.
+func NewSubscribeOperation(msg *Message) *SubscribeOperation {
+	return &SubscribeOperation{Operation: *NewOperation(OperationTypeSubscribe, msg)}
+}
+
 func (o SubscribeOperation) MapStructureDefaults() map[string]interface{} {
 	return map[string]interface{}{
 		"operationType": OperationTypeSubscribe,
 	}
+}
+
+// NewPublishOperation creates a new PublishOperation. Useful for testing.
+func NewPublishOperation(msg *Message) *PublishOperation {
+	return &PublishOperation{Operation: *NewOperation(OperationTypePublish, msg)}
 }
 
 type PublishOperation struct {
@@ -264,6 +281,19 @@ func (o PublishOperation) MapStructureDefaults() map[string]interface{} {
 	return map[string]interface{}{
 		"operationType": OperationTypePublish,
 	}
+}
+
+// NewOperation creates a new Operation. Useful for testing.
+func NewOperation(operationType asyncapi.OperationType, msg *Message) *Operation {
+	op := &Operation{
+		OperationType: operationType,
+	}
+
+	if msg != nil {
+		op.MessageField = msg
+	}
+
+	return op
 }
 
 type Operation struct {
@@ -377,57 +407,57 @@ func (s Schemas) ToInterface(dst map[string]asyncapi.Schema) map[string]asyncapi
 
 type Schema struct {
 	Extendable
-	AdditionalItemsField      *Schema           `mapstructure:"additionalItems"`
-	AdditionalPropertiesField *Schema           `mapstructure:"additionalProperties"`
-	AllOfField                []asyncapi.Schema `mapstructure:"allOf"`
-	AnyOfField                []asyncapi.Schema `mapstructure:"anyOf"`
-	ConstField                interface{}       `mapstructure:"const"`
-	ContainsField             *Schema           `mapstructure:"contains"`
-	ContentEncodingField      string            `mapstructure:"contentEncoding"`
-	ContentMediaTypeField     string            `mapstructure:"contentMediaType"`
-	DefaultField              interface{}       `mapstructure:"default"`
-	DefinitionsField          Schemas           `mapstructure:"definitions"`
-	DependenciesField         Schemas           `mapstructure:"dependencies"`
-	DeprecatedField           bool              `mapstructure:"deprecated"`
-	DescriptionField          string            `mapstructure:"description"`
-	DiscriminatorField        string            `mapstructure:"discriminator"`
-	ElseField                 *Schema           `mapstructure:"else"`
-	EnumField                 []interface{}     `mapstructure:"enum"`
-	ExamplesField             []interface{}     `mapstructure:"examples"`
-	ExclusiveMaximumField     *float64          `mapstructure:"exclusiveMaximum"`
-	ExclusiveMinimumField     *float64          `mapstructure:"exclusiveMinimum"`
-	FormatField               string            `mapstructure:"format"`
-	IDField                   string            `mapstructure:"$id"`
-	IfField                   *Schema           `mapstructure:"if"`
-	ItemsField                []asyncapi.Schema `mapstructure:"items"`
-	MaximumField              *float64          `mapstructure:"maximum"`
-	MaxItemsField             *float64          `mapstructure:"maxItems"`
-	MaxLengthField            *float64          `mapstructure:"maxLength"`
-	MaxPropertiesField        *float64          `mapstructure:"maxProperties"`
-	MinimumField              *float64          `mapstructure:"minimum"`
-	MinItemsField             *float64          `mapstructure:"minItems"`
-	MinLengthField            *float64          `mapstructure:"minLength"`
-	MinPropertiesField        *float64          `mapstructure:"minProperties"`
-	MultipleOfField           *float64          `mapstructure:"multipleOf"`
-	NotField                  *Schema           `mapstructure:"not"`
-	OneOfField                *Schema           `mapstructure:"oneOf"`
-	PatternField              string            `mapstructure:"pattern"`
-	PatternPropertiesField    Schemas           `mapstructure:"patternProperties"`
-	PropertiesField           Schemas           `mapstructure:"properties"`
-	PropertyNamesField        *Schema           `mapstructure:"propertyNames"`
-	ReadOnlyField             bool              `mapstructure:"readOnly"`
-	RequiredField             string            `mapstructure:"required"`
-	ThenField                 *Schema           `mapstructure:"then"`
-	TitleField                string            `mapstructure:"title"`
-	TypeField                 interface{}       `mapstructure:"type"` // string | []string
-	UniqueItemsField          bool              `mapstructure:"uniqueItems"`
-	WriteOnlyField            bool              `mapstructure:"writeOnly"`
+	AdditionalItemsField      *Schema           `mapstructure:"additionalItems" json:"additionalItems,omitempty"`
+	AdditionalPropertiesField *Schema           `mapstructure:"additionalProperties" json:"additionalProperties,omitempty"`
+	AllOfField                []asyncapi.Schema `mapstructure:"allOf" json:"allOf,omitempty"`
+	AnyOfField                []asyncapi.Schema `mapstructure:"anyOf" json:"anyOf,omitempty"`
+	ConstField                interface{}       `mapstructure:"const" json:"const,omitempty"`
+	ContainsField             *Schema           `mapstructure:"contains" json:"contains,omitempty"`
+	ContentEncodingField      string            `mapstructure:"contentEncoding" json:"contentEncoding,omitempty"`
+	ContentMediaTypeField     string            `mapstructure:"contentMediaType" json:"contentMediaType,omitempty"`
+	DefaultField              interface{}       `mapstructure:"default" json:"default,omitempty"`
+	DefinitionsField          Schemas           `mapstructure:"definitions" json:"definitions,omitempty"`
+	DependenciesField         Schemas           `mapstructure:"dependencies" json:"dependencies,omitempty"`
+	DeprecatedField           bool              `mapstructure:"deprecated" json:"deprecated,omitempty"`
+	DescriptionField          string            `mapstructure:"description" json:"description,omitempty"`
+	DiscriminatorField        string            `mapstructure:"discriminator" json:"discriminator,omitempty"`
+	ElseField                 *Schema           `mapstructure:"else" json:"else,omitempty"`
+	EnumField                 []interface{}     `mapstructure:"enum" json:"enum,omitempty"`
+	ExamplesField             []interface{}     `mapstructure:"examples" json:"examples,omitempty"`
+	ExclusiveMaximumField     *float64          `mapstructure:"exclusiveMaximum" json:"exclusiveMaximum,omitempty"`
+	ExclusiveMinimumField     *float64          `mapstructure:"exclusiveMinimum" json:"exclusiveMinimum,omitempty"`
+	FormatField               string            `mapstructure:"format" json:"format,omitempty"`
+	IDField                   string            `mapstructure:"$id" json:"$id,omitempty"`
+	IfField                   *Schema           `mapstructure:"if" json:"if,omitempty"`
+	ItemsField                []asyncapi.Schema `mapstructure:"items" json:"items,omitempty"`
+	MaximumField              *float64          `mapstructure:"maximum" json:"maximum,omitempty"`
+	MaxItemsField             *float64          `mapstructure:"maxItems" json:"maxItems,omitempty"`
+	MaxLengthField            *float64          `mapstructure:"maxLength" json:"maxLength,omitempty"`
+	MaxPropertiesField        *float64          `mapstructure:"maxProperties" json:"maxProperties,omitempty"`
+	MinimumField              *float64          `mapstructure:"minimum" json:"minimum,omitempty"`
+	MinItemsField             *float64          `mapstructure:"minItems" json:"minItems,omitempty"`
+	MinLengthField            *float64          `mapstructure:"minLength" json:"minLength,omitempty"`
+	MinPropertiesField        *float64          `mapstructure:"minProperties" json:"minProperties,omitempty"`
+	MultipleOfField           *float64          `mapstructure:"multipleOf" json:"multipleOf,omitempty"`
+	NotField                  *Schema           `mapstructure:"not" json:"not,omitempty"`
+	OneOfField                *Schema           `mapstructure:"oneOf" json:"oneOf,omitempty"`
+	PatternField              string            `mapstructure:"pattern" json:"pattern,omitempty"`
+	PatternPropertiesField    Schemas           `mapstructure:"patternProperties" json:"patternProperties,omitempty"`
+	PropertiesField           Schemas           `mapstructure:"properties" json:"properties,omitempty"`
+	PropertyNamesField        *Schema           `mapstructure:"propertyNames" json:"propertyNames,omitempty"`
+	ReadOnlyField             bool              `mapstructure:"readOnly" json:"readOnly,omitempty"`
+	RequiredField             []string          `mapstructure:"required" json:"required,omitempty"`
+	ThenField                 *Schema           `mapstructure:"then" json:"then,omitempty"`
+	TitleField                string            `mapstructure:"title" json:"title,omitempty"`
+	TypeField                 interface{}       `mapstructure:"type" json:"type"` // string | []string
+	UniqueItemsField          bool              `mapstructure:"uniqueItems" json:"uniqueItems,omitempty"`
+	WriteOnlyField            bool              `mapstructure:"writeOnly" json:"writeOnly,omitempty"`
 
 	// cached converted map[string]asyncapi.Schema from map[string]*Schema
-	propertiesFieldMap        map[string]asyncapi.Schema
-	patternPropertiesFieldMap map[string]asyncapi.Schema
-	DefinitionsFieldMap       map[string]asyncapi.Schema
-	DependenciesFieldMap      map[string]asyncapi.Schema
+	propertiesFieldMap        map[string]asyncapi.Schema `json:"-"`
+	patternPropertiesFieldMap map[string]asyncapi.Schema `json:"-"`
+	DefinitionsFieldMap       map[string]asyncapi.Schema `json:"-"`
+	DependenciesFieldMap      map[string]asyncapi.Schema `json:"-"`
 }
 
 func (s *Schema) AdditionalItems() asyncapi.Schema {
@@ -617,8 +647,7 @@ func (s *Schema) ReadOnly() bool {
 	return s.ReadOnlyField
 }
 
-func (s *Schema) Required() string {
-	// TODO string[]
+func (s *Schema) Required() []string {
 	return s.RequiredField
 }
 
@@ -759,7 +788,7 @@ func (d Describable) HasDescription() bool {
 }
 
 type Extendable struct {
-	Raw map[string]interface{} `mapstructure:",remain"`
+	Raw map[string]interface{} `mapstructure:",remain" json:"-"`
 }
 
 func (e Extendable) HasExtension(name string) bool {

--- a/asyncapi/v2/v2_test.go
+++ b/asyncapi/v2/v2_test.go
@@ -1,0 +1,84 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asyncapi/event-gateway/asyncapi"
+)
+
+func TestMessage_OneOfPayload_MultipleMessages(t *testing.T) {
+	oneOfSchemas := []asyncapi.Schema{
+		&Schema{
+			PropertiesField: map[string]*Schema{
+				"schemaOnefieldOne": {},
+				"schemaOnefieldTwo": {},
+			},
+		},
+		&Schema{
+			PropertiesField: map[string]*Schema{
+				"schemaTwofieldOne": {},
+				"schemaTWofieldTwo": {},
+			},
+		},
+	}
+	msg := &Message{
+		PayloadField: &Schema{
+			OneOfField: oneOfSchemas,
+		},
+	}
+
+	msgs := NewSubscribeOperation(msg).Messages()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, oneOfSchemas[0], msgs[0].Payload())
+	assert.Equal(t, oneOfSchemas[1], msgs[1].Payload())
+}
+
+func TestMessage_PlainPayload_OneMessage(t *testing.T) {
+	msg := &Message{
+		PayloadField: &Schema{
+			PropertiesField: map[string]*Schema{
+				"schemaFieldOne":      {},
+				"schemaFieldfieldTwo": {},
+			},
+		},
+	}
+
+	msgs := NewSubscribeOperation(msg).Messages()
+	require.Len(t, msgs, 1)
+	assert.Equal(t, msg, msgs[0])
+}
+
+func TestSchema_AdditionalProperties(t *testing.T) {
+	schema := &Schema{}
+	assert.Nil(t, schema.AdditionalProperties())
+
+	schema = &Schema{AdditionalPropertiesField: false}
+	assert.True(t, schema.AdditionalProperties().IsFalse())
+	assert.False(t, schema.AdditionalProperties().IsSchema())
+	assert.Nil(t, schema.AdditionalProperties().Schema())
+
+	field := &Schema{TypeField: "string"}
+	schema = &Schema{AdditionalPropertiesField: field}
+	assert.False(t, schema.AdditionalProperties().IsFalse())
+	assert.True(t, schema.AdditionalProperties().IsSchema())
+	assert.Equal(t, field, schema.AdditionalProperties().Schema())
+}
+
+func TestSchema_AdditionalItems(t *testing.T) {
+	schema := &Schema{}
+	assert.Nil(t, schema.AdditionalItems())
+
+	schema = &Schema{AdditionalItemsField: false}
+	assert.True(t, schema.AdditionalItems().IsFalse())
+	assert.False(t, schema.AdditionalItems().IsSchema())
+	assert.Nil(t, schema.AdditionalItems().Schema())
+
+	field := &Schema{TypeField: "string"}
+	schema = &Schema{AdditionalItemsField: field}
+	assert.False(t, schema.AdditionalItems().IsFalse())
+	assert.True(t, schema.AdditionalItems().IsSchema())
+	assert.Equal(t, field, schema.AdditionalItems().Schema())
+}

--- a/asyncapi/v2/validation.go
+++ b/asyncapi/v2/validation.go
@@ -1,0 +1,50 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asyncapi/event-gateway/asyncapi"
+	"github.com/asyncapi/event-gateway/proxy"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func FromDocJSONSchemaMessageValidator(doc asyncapi.Document) (proxy.MessageValidator, error) {
+	channels := doc.ApplicationSubscribableChannels()
+	messageSchemas := make(map[string]gojsonschema.JSONLoader)
+	for _, c := range channels {
+		for _, o := range c.Operations() {
+			if !o.IsApplicationSubscribing() {
+				continue
+			}
+
+			// Assuming there is only one message per operation as per Asyncapi 2.x.x.
+			// See https://github.com/asyncapi/event-gateway/issues/10
+			if len(o.Messages()) > 1 {
+				return nil, fmt.Errorf("can not generate message validation for operation %s. Reason: the operation has more than one message and we can't correlate which one is it", o.ID())
+			}
+
+			if len(o.Messages()) == 0 {
+				return nil, fmt.Errorf("can not generate message validation for operation %s. Reason:. Operation has no message. This is totally unexpected", o.ID())
+			}
+
+			// Assuming there is only one message per operation and one operation of a particular type per Channel.
+			// See https://github.com/asyncapi/event-gateway/issues/10
+			msg := o.Messages()[0]
+
+			raw, err := json.Marshal(msg.Payload())
+			if err != nil {
+				return nil, fmt.Errorf("error marshaling message payload for generating json schema for validation. Operation: %s, Message: %s", o.ID(), msg.Name())
+			}
+
+			messageSchemas[c.ID()] = gojsonschema.NewBytesLoader(raw)
+		}
+	}
+
+	idProvider := func(msg *proxy.Message) string {
+		// messageSchemas map is indexed by Channel name, so we need to tell the validator.
+		return msg.Context.Channel
+	}
+
+	return proxy.JSONSchemaMessageValidator(messageSchemas, idProvider)
+}

--- a/asyncapi/v2/validation_test.go
+++ b/asyncapi/v2/validation_test.go
@@ -3,59 +3,96 @@ package v2
 import (
 	"testing"
 
+	"github.com/asyncapi/event-gateway/asyncapi"
+
 	"github.com/asyncapi/event-gateway/proxy"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFromDocJsonSchemaMessageValidator(t *testing.T) {
-	msg := &Message{
-		PayloadField: &Schema{
-			TypeField: "object",
-			PropertiesField: Schemas{
-				"AnIntergerField": &Schema{
-					Extendable:    Extendable{},
-					MaximumField:  refFloat64(10),
-					MinimumField:  refFloat64(3),
-					RequiredField: []string{"AnIntergerField"},
-					TypeField:     "number",
-				},
-			},
-		},
-	}
-	channel := NewChannel("test")
-	channel.Subscribe = NewSubscribeOperation(msg)
-
-	doc := Document{
-		Extendable: Extendable{},
-		ChannelsField: map[string]Channel{
-			"test": *channel,
-		},
-	}
-
 	tests := []struct {
 		name    string
 		valid   bool
+		schema  *Schema
 		payload []byte
 	}{
 		{
-			name:    "Valid payload",
+			name: "Valid payload",
+			schema: &Schema{
+				TypeField: "object",
+				PropertiesField: Schemas{
+					"AnIntergerField": &Schema{
+						MaximumField:  refFloat64(10),
+						MinimumField:  refFloat64(3),
+						RequiredField: []string{"AnIntergerField"},
+						TypeField:     "number",
+					},
+				},
+			},
 			payload: []byte(`{"AnIntergerField": 5}`),
 			valid:   true,
 		},
 		{
-			name:    "Invalid payload",
+			name: "Valid multiple payloads",
+			schema: &Schema{
+				TypeField: "object",
+				OneOfField: []asyncapi.Schema{
+					&Schema{
+						PropertiesField: Schemas{
+							"AnIntergerField": &Schema{
+								MaximumField:  refFloat64(10),
+								MinimumField:  refFloat64(3),
+								RequiredField: []string{"AnIntergerField"},
+								TypeField:     "number",
+							},
+						},
+						AdditionalPropertiesField: false,
+					},
+					&Schema{
+						PropertiesField: Schemas{
+							"AStringField": &Schema{
+								RequiredField: []string{"AStringField"},
+								TypeField:     "string",
+							},
+						},
+						AdditionalPropertiesField: false,
+					},
+				},
+			},
+			payload: []byte(`{"AStringField": "hello!"}`),
+			valid:   true,
+		},
+		{
+			name: "Invalid payload",
+			schema: &Schema{
+				TypeField: "object",
+				PropertiesField: Schemas{
+					"AnIntergerField": &Schema{
+						MaximumField:  refFloat64(10),
+						MinimumField:  refFloat64(3),
+						RequiredField: []string{"AnIntergerField"},
+						TypeField:     "number",
+					},
+				},
+			},
 			payload: []byte(`{"AnIntergerField": 1}`),
 			valid:   false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// Doc generation
+			channel := NewChannel(t.Name())
+			channel.Subscribe = NewSubscribeOperation(&Message{PayloadField: test.schema})
+			doc := Document{ChannelsField: map[string]Channel{t.Name(): *channel}}
+
+			// Test
 			validator, err := FromDocJSONSchemaMessageValidator(doc)
 			assert.NoError(t, err)
 
 			msg := &proxy.Message{
 				Context: proxy.MessageContext{
-					Channel: "test",
+					Channel: t.Name(),
 				},
 				Value: test.payload,
 			}

--- a/asyncapi/v2/validation_test.go
+++ b/asyncapi/v2/validation_test.go
@@ -1,0 +1,73 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/asyncapi/event-gateway/proxy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromDocJsonSchemaMessageValidator(t *testing.T) {
+	msg := &Message{
+		PayloadField: &Schema{
+			TypeField: "object",
+			PropertiesField: Schemas{
+				"AnIntergerField": &Schema{
+					Extendable:    Extendable{},
+					MaximumField:  refFloat64(10),
+					MinimumField:  refFloat64(3),
+					RequiredField: []string{"AnIntergerField"},
+					TypeField:     "number",
+				},
+			},
+		},
+	}
+	channel := NewChannel("test")
+	channel.Subscribe = NewSubscribeOperation(msg)
+
+	doc := Document{
+		Extendable: Extendable{},
+		ChannelsField: map[string]Channel{
+			"test": *channel,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		valid   bool
+		payload []byte
+	}{
+		{
+			name:    "Valid payload",
+			payload: []byte(`{"AnIntergerField": 5}`),
+			valid:   true,
+		},
+		{
+			name:    "Invalid payload",
+			payload: []byte(`{"AnIntergerField": 1}`),
+			valid:   false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validator, err := FromDocJSONSchemaMessageValidator(doc)
+			assert.NoError(t, err)
+
+			msg := &proxy.Message{
+				Context: proxy.MessageContext{
+					Channel: "test",
+				},
+				Value: test.payload,
+			}
+			validationErr, err := validator(msg)
+			assert.NoError(t, err)
+
+			if test.valid {
+				assert.Nil(t, validationErr)
+			} else {
+				assert.NotNil(t, validationErr)
+				assert.False(t, validationErr.Result.Valid())
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,21 @@ import (
 // App holds the config for the whole application.
 type App struct {
 	Debug       bool
-	AsyncAPIDoc []byte     `split_words:"true"`
-	KafkaProxy  KafkaProxy `split_words:"true"`
+	AsyncAPIDoc []byte      `split_words:"true"`
+	KafkaProxy  *KafkaProxy `split_words:"true"`
+}
+
+// Opt is a functional option used for configuring an App.
+type Opt func(*App)
+
+// NewApp creates a App config with defaults.
+func NewApp(opts ...Opt) *App {
+	c := &App{KafkaProxy: NewKafkaProxy()}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }
 
 // ProxyConfig creates a config struct for the Kafka Proxy.

--- a/config/kafka.go
+++ b/config/kafka.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/asyncapi/event-gateway/proxy"
+
 	"github.com/asyncapi/event-gateway/asyncapi"
 	v2 "github.com/asyncapi/event-gateway/asyncapi/v2"
 	"github.com/asyncapi/event-gateway/kafka"
@@ -17,10 +19,31 @@ type KafkaProxy struct {
 	BrokersMapping     pipeSeparatedValues `split_words:"true"`
 	BrokersDialMapping pipeSeparatedValues `split_words:"true"`
 	ExtraFlags         pipeSeparatedValues `split_words:"true"`
+	MessageValidation  MessageValidation   `split_words:"true"`
+}
+
+// MessageValidation holds the config about message validation.
+type MessageValidation struct {
+	Enabled  bool
+	Notifier proxy.ValidationErrorNotifier
+}
+
+// NotifyValidationErrorOnChan sets a channel as ValidationError notifier.
+func NotifyValidationErrorOnChan(errChan chan *proxy.ValidationError) Opt {
+	return func(app *App) {
+		app.KafkaProxy.MessageValidation.Notifier = proxy.ValidationErrorToChanNotifier(errChan)
+	}
+}
+
+// NewKafkaProxy creates a KafkaProxy with defaults.
+func NewKafkaProxy() *KafkaProxy {
+	return &KafkaProxy{MessageValidation: MessageValidation{
+		Enabled: true,
+	}}
 }
 
 // ProxyConfig creates a config struct for the Kafka Proxy based on a given AsyncAPI doc (if provided).
-func (c *KafkaProxy) ProxyConfig(doc []byte, debug bool) (*kafka.ProxyConfig, error) {
+func (c *KafkaProxy) ProxyConfig(doc []byte, debug bool, messageHandlers ...kafka.MessageHandler) (*kafka.ProxyConfig, error) {
 	if len(doc) == 0 && len(c.BrokersMapping.Values) == 0 {
 		return nil, errors.New("either AsyncAPIDoc or KafkaProxyBrokersMapping config should be provided")
 	}
@@ -42,6 +65,7 @@ func (c *KafkaProxy) ProxyConfig(doc []byte, debug bool) (*kafka.ProxyConfig, er
 	}
 
 	kafkaProxyConfig.Debug = debug
+	kafkaProxyConfig.MessageHandlers = append(kafkaProxyConfig.MessageHandlers, messageHandlers...)
 
 	return kafkaProxyConfig, nil
 }
@@ -52,18 +76,32 @@ func (c *KafkaProxy) configFromDoc(d []byte) (*kafka.ProxyConfig, error) {
 		return nil, errors.Wrap(err, "error decoding AsyncAPI json doc to Document struct")
 	}
 
-	if c.BrokerFromServer != "" {
-		return kafkaProxyConfigFromServer(c.BrokerFromServer, doc)
+	var opts []kafka.Option
+	if c.MessageValidation.Enabled {
+		validator, err := v2.FromDocJSONSchemaMessageValidator(doc)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating message validator")
+		}
+
+		if notifier := c.MessageValidation.Notifier; notifier != nil {
+			validator = proxy.NotifyOnValidationError(validator, notifier)
+		}
+
+		opts = append(opts, kafka.WithMessageHandlers(validateMessageHandler(validator)))
 	}
 
-	return kafkaProxyConfigFromAllServers(doc.Servers())
+	if c.BrokerFromServer != "" {
+		return kafkaProxyConfigFromServer(c.BrokerFromServer, doc, opts...)
+	}
+
+	return kafkaProxyConfigFromAllServers(doc.Servers(), opts...)
 }
 
 func isValidKafkaProtocol(s asyncapi.Server) bool {
 	return strings.HasPrefix(s.Protocol(), "kafka")
 }
 
-func kafkaProxyConfigFromAllServers(servers []asyncapi.Server) (*kafka.ProxyConfig, error) {
+func kafkaProxyConfigFromAllServers(servers []asyncapi.Server, opts ...kafka.Option) (*kafka.ProxyConfig, error) {
 	var brokersMapping []string
 	var dialAddressMapping []string
 	for _, s := range servers {
@@ -82,10 +120,12 @@ func kafkaProxyConfigFromAllServers(servers []asyncapi.Server) (*kafka.ProxyConf
 		}
 	}
 
-	return kafka.NewProxyConfig(brokersMapping, kafka.WithDialAddressMapping(dialAddressMapping))
+	opts = append(opts, kafka.WithDialAddressMapping(dialAddressMapping))
+
+	return kafka.NewProxyConfig(brokersMapping, opts...)
 }
 
-func kafkaProxyConfigFromServer(name string, doc asyncapi.Document) (*kafka.ProxyConfig, error) {
+func kafkaProxyConfigFromServer(name string, doc asyncapi.Document, opts ...kafka.Option) (*kafka.ProxyConfig, error) {
 	s, ok := doc.Server(name)
 	if !ok {
 		return nil, fmt.Errorf("server %s not found in the provided AsyncAPI doc", name)
@@ -101,10 +141,35 @@ func kafkaProxyConfigFromServer(name string, doc asyncapi.Document) (*kafka.Prox
 		return nil, errors.Wrapf(err, "error getting port from broker %s. URL:%s", s.Name(), s.URL())
 	}
 
-	var opts []kafka.Option
 	if dialMapping := s.Extension(asyncapi.ExtensionEventGatewayDialMapping); dialMapping != nil {
 		opts = append(opts, kafka.WithDialAddressMapping([]string{fmt.Sprintf("%s,%s", s.URL(), dialMapping)}))
 	}
 
 	return kafka.NewProxyConfig([]string{fmt.Sprintf("%s,:%s", s.URL(), port)}, opts...)
+}
+
+func validateMessageHandler(validator proxy.MessageValidator) kafka.MessageHandler {
+	return func(msg kafka.Message) error {
+		pMsg := &proxy.Message{
+			Context: proxy.MessageContext{
+				Channel: msg.Context.Topic,
+			},
+			Key:   msg.Key,
+			Value: msg.Value,
+		}
+
+		if len(msg.Headers) > 0 {
+			pMsg.Headers = make([]proxy.MessageHeader, len(msg.Headers))
+			for i := 0; i < len(msg.Headers); i++ {
+				pMsg.Headers[i] = proxy.MessageHeader{
+					Key:   msg.Headers[i].Key,
+					Value: msg.Headers[i].Value,
+				}
+			}
+		}
+
+		_, err := validator(pMsg)
+
+		return err
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xdg/scram v1.0.3 // indirect
 	github.com/xdg/stringprep v1.0.3 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
 	golang.org/x/net v0.0.0-20210427231257-85d9c07bbe3a // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,12 +171,14 @@ github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.3 h1:cmL5Enob4W83ti/ZHuZLuKD/xqJfus4fVPwE+/BDm+4=
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b h1:6cLsL+2FW6dRAdl5iMtHgRogVCff0QpRi9653YmdcJA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.1.0 h1:ngVtJC9TY/lg0AA/1k48FYhBrhRoFlEmWzsehpNAaZg=
 github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/proxy/validation.go
+++ b/proxy/validation.go
@@ -1,0 +1,106 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// Message represents a message flowing through the wire. For example, a Kafka message.
+type Message struct {
+	Context MessageContext
+	Key     []byte
+	Value   []byte
+	Headers []MessageHeader
+}
+
+// MessageContext contains information about the context that surrounds a message.
+type MessageContext struct {
+	Channel string
+}
+
+// MessageHeader represents a header of a message, if there are any.
+type MessageHeader struct {
+	Key   []byte
+	Value []byte
+}
+
+// ValidationError represents a message validation error.
+type ValidationError struct {
+	Msg    *Message
+	Result *gojsonschema.Result
+}
+
+func (v ValidationError) String() string {
+	errs := make([]string, len(v.Result.Errors()))
+	for i, err := range v.Result.Errors() {
+		errs[i] = err.String()
+	}
+
+	return strings.Join(errs, " | ")
+}
+
+// ValidationErrorNotifier notifies whenever a ValidationError happens.
+type ValidationErrorNotifier func(validationError *ValidationError) error
+
+// ValidationErrorToChanNotifier notifies to a given chan when a ValidationError happens.
+func ValidationErrorToChanNotifier(errChan chan *ValidationError) ValidationErrorNotifier {
+	return func(validationError *ValidationError) error {
+		// TODO Blocking or non blocking? Shall we just fire and forget via goroutine instead?
+		errChan <- validationError
+
+		return nil
+	}
+}
+
+// MessageValidator validates a message.
+// Returns a boolean indicating if the message is valid, and an error if something went wrong.
+type MessageValidator func(*Message) (*ValidationError, error)
+
+// NotifyOnValidationError is a MessageValidator that notifies ValidationError from a given MessageValidator output to the given channel.
+func NotifyOnValidationError(validator MessageValidator, notifier ValidationErrorNotifier) MessageValidator {
+	return func(msg *Message) (*ValidationError, error) {
+		validationErr, err := validator(msg)
+		if err != nil {
+			return nil, err
+		}
+
+		if validationErr != nil {
+			if err := notifier(validationErr); err != nil {
+				return nil, errors.Wrap(err, "error notifying validation error")
+			}
+
+			return validationErr, nil
+		}
+
+		return nil, nil
+	}
+}
+
+// JSONSchemaMessageValidator validates a message payload based on a map of Json Schema, where the key can be any identifier  (depends on who implements it).
+// For example, the identifier can be it's channel name, message ID, etc.
+func JSONSchemaMessageValidator(messageSchemas map[string]gojsonschema.JSONLoader, idProvider func(msg *Message) string) (MessageValidator, error) {
+	return func(msg *Message) (*ValidationError, error) {
+		msgID := idProvider(msg)
+		msgSchema, ok := messageSchemas[msgID]
+		if !ok {
+			return nil, nil
+		}
+
+		result, err := gojsonschema.Validate(msgSchema, gojsonschema.NewBytesLoader(msg.Value))
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("error validating JSON Schema for message %s", msgID))
+		}
+
+		if !result.Valid() {
+			return &ValidationError{
+				Msg:    msg,
+				Result: result,
+			}, nil
+		}
+
+		return nil, nil
+	}, nil
+}

--- a/proxy/validation_test.go
+++ b/proxy/validation_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestValidationError_String(t *testing.T) {
+	validationErr := generateTestValidationError(nil)
+	assert.Equal(t, "AnIntegerField: Invalid type. Expected: integer, given: string | AStringField: Invalid type. Expected: string, given: integer", validationErr.String())
+}
+
+func TestNotifyOnValidationError(t *testing.T) {
+	expectedMessage := generateTestMessage()
+	validator := func(msg *Message) (*ValidationError, error) {
+		assert.Equal(t, expectedMessage, msg)
+		return generateTestValidationError(msg), nil
+	}
+
+	var notified bool
+	notifier := func(validationError *ValidationError) error {
+		notified = true
+		return nil
+	}
+
+	validationErr, err := NotifyOnValidationError(validator, notifier)(expectedMessage)
+	assert.NoError(t, err)
+	assert.False(t, validationErr.Result.Valid())
+	assert.True(t, notified)
+}
+
+func generateTestMessage() *Message {
+	return &Message{
+		Context: MessageContext{Channel: "test"},
+		Value:   []byte(`Hello World!`),
+	}
+}
+
+func generateTestValidationError(msg *Message) *ValidationError {
+	validationErr := &ValidationError{
+		Msg:    msg,
+		Result: &gojsonschema.Result{},
+	}
+
+	addTestErrors(validationErr)
+	return validationErr
+}
+
+func addTestErrors(validationErr *ValidationError) {
+	badTypeErr := &gojsonschema.InvalidTypeError{}
+	badTypeErr.SetContext(gojsonschema.NewJsonContext("AnIntegerField", nil))
+	badTypeErr.SetDetails(gojsonschema.ErrorDetails{
+		"expected": gojsonschema.TYPE_INTEGER,
+		"given":    gojsonschema.TYPE_STRING,
+	})
+	badTypeErr.SetDescriptionFormat(gojsonschema.Locale.InvalidType())
+	validationErr.Result.AddError(badTypeErr, badTypeErr.Details())
+
+	badTypeErr2 := &gojsonschema.InvalidTypeError{}
+	badTypeErr2.SetContext(gojsonschema.NewJsonContext("AStringField", nil))
+	badTypeErr2.SetDetails(gojsonschema.ErrorDetails{
+		"expected": gojsonschema.TYPE_STRING,
+		"given":    gojsonschema.TYPE_INTEGER,
+	})
+	badTypeErr2.SetDescriptionFormat(gojsonschema.Locale.InvalidType())
+	validationErr.Result.AddError(badTypeErr2, badTypeErr2.Details())
+}
+
+func TestJsonSchemaMessageValidator(t *testing.T) {
+	schema := `{
+   "properties":{
+      "command":{
+         "description":"Whether to turn on or off the light.",
+         "enum":[
+            "on",
+            "off"
+         ],
+         "type":"string"
+      }
+   },
+   "type":"object"
+}`
+
+	tests := []struct {
+		name    string
+		valid   bool
+		payload []byte
+	}{
+		{
+			name:    "Valid payload",
+			payload: []byte(`{"command": "on"}`),
+			valid:   true,
+		},
+		{
+			name:    "Invalid payload",
+			payload: []byte(`{"command": 123123}`),
+			valid:   false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectedMsg := generateTestMessage()
+			expectedMsg.Value = test.payload
+
+			idToSchemaMap := map[string]gojsonschema.JSONLoader{
+				expectedMsg.Context.Channel: gojsonschema.NewStringLoader(schema),
+			}
+
+			validator, err := JSONSchemaMessageValidator(idToSchemaMap, func(msg *Message) string {
+				assert.Equal(t, expectedMsg, msg)
+				return msg.Context.Channel
+			})
+			assert.NoError(t, err)
+
+			validationErr, err := validator(expectedMsg)
+			assert.NoError(t, err)
+
+			if test.valid {
+				assert.Nil(t, validationErr)
+			} else {
+				assert.NotNil(t, validationErr)
+				assert.False(t, validationErr.Result.Valid())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This PR adds the required code to validate Kafka message against a JSON Schema document, which is grabbed from the message payload declared in the AsyncAPI document.

It introduces a new error validation notification mechanism, that allows configuring a Go channel where all validation errors will flow. Now the behavior is just logging those validation errors.

You can see a demo of this feature working [here](https://cln.sh/QZg3RT)

**Related issue(s)**
Fixes https://github.com/asyncapi/event-gateway/issues/10