### PR TITLE
feat: add websocket endpoint to receive validation errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,9 +8,10 @@ import (
 
 // App holds the config for the whole application.
 type App struct {
-	Debug       bool
-	AsyncAPIDoc []byte      `split_words:"true"`
-	KafkaProxy  *KafkaProxy `split_words:"true"`
+	Debug        bool
+	AsyncAPIDoc  []byte      `split_words:"true"`
+	KafkaProxy   *KafkaProxy `split_words:"true"`
+	WSServerPort int         `split_words:"true" default:"5000"`
 }
 
 // Opt is a functional option used for configuring an App.

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,14 @@ require (
 	github.com/asyncapi/parser-go v0.3.1-0.20210701222435-43ab3e4b47d6
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
 	github.com/frankban/quicktest v1.11.3 // indirect
+	github.com/go-chi/chi/v5 v5.0.3
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grepplabs/kafka-proxy v0.2.8
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/klauspost/compress v1.12.2
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
+	github.com/olahol/melody v0.0.0-20180227134253-7bd65910e5ab
 	github.com/pierrec/lz4 v2.6.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-chi/chi/v5 v5.0.3 h1:khYQBdPivkYG1s1TAzDQG1f6eX4kD2TItYVZexL5rS4=
+github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap/v3 v3.2.3/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
@@ -63,6 +65,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-hclog v0.0.0-20180122232401-5bcb0f17e364 h1:Q30cq6GgGiEGzz3jxQELCRfCoST5Cqqegs4WV4/u/uM=
 github.com/hashicorp/go-hclog v0.0.0-20180122232401-5bcb0f17e364/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
@@ -111,6 +115,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/olahol/melody v0.0.0-20180227134253-7bd65910e5ab h1:2fsluM+sAZRIQtvloPaokkWWjV8strYfmXsDCtZMqt0=
+github.com/olahol/melody v0.0.0-20180227134253-7bd65910e5ab/go.mod h1:3lo03f1jM3KFUG/rsujuLB1rBmlvIzVM3SCqbuHqsBU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/kafka/proxy.go
+++ b/kafka/proxy.go
@@ -138,6 +138,7 @@ func (h *produceRequestHandler) extractMessages(req protocol.ProduceRequest) []M
 						Context: Context{
 							Topic: topic,
 						},
+						Key:     r.Key,
 						Value:   r.Value,
 						Headers: r.Headers,
 					})
@@ -149,8 +150,8 @@ func (h *produceRequestHandler) extractMessages(req protocol.ProduceRequest) []M
 						Context: Context{
 							Topic: topic,
 						},
-						Value: mb.Msg.Value,
 						Key:   mb.Msg.Key,
+						Value: mb.Msg.Value,
 					})
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -2,16 +2,20 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/asyncapi/event-gateway/proxy"
-
 	"github.com/asyncapi/event-gateway/config"
 	"github.com/asyncapi/event-gateway/kafka"
+	"github.com/asyncapi/event-gateway/proxy"
+	"github.com/go-chi/chi/v5"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/olahol/melody"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,19 +41,46 @@ func main() {
 		logrus.WithError(err).Fatal()
 	}
 
+	m := melody.New()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	handleInterruptions(cancel)
+	handleInterruptions(cancel, func() error {
+		return m.CloseWithMsg(melody.FormatCloseMessage(1000, "The server says goodbye :)"))
+	})
 
-	// At this moment, we do nothing else.
-	go logValidationErrors(ctx, validationErrChan)
+	r := chi.NewRouter()
+	r.Get("/", http.FileServer(http.Dir("./web/static")).ServeHTTP)
+	r.Get("/ws", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
 
+	go func() {
+		address := fmt.Sprintf(":%v", c.WSServerPort)
+		logrus.Infof("Websocket server listening on %s", address)
+		if err := http.ListenAndServe(address, r); err != nil {
+			logrus.WithError(err).Fatal("error running websocket server")
+		}
+	}()
+
+	go handleValidationErrors(ctx, validationErrChan, m)
 	if err := kafkaProxy(context.Background()); err != nil {
 		logrus.WithError(err).Fatal()
 	}
 }
 
-func logValidationErrors(ctx context.Context, validationErrChan chan *proxy.ValidationError) {
+func handleValidationErrors(ctx context.Context, validationErrChan chan *proxy.ValidationError, m *melody.Melody) {
+	// Using logrus for handling ws output text.
+	noopLogger := logrus.New()
+	noopLogger.Out = io.Discard
+
+	// Using logrus formatter for ws output text.
+	f := logrus.TextFormatter{
+		ForceQuote:      true,
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339,
+	}
+
 	for {
 		select {
 		case validationErr, ok := <-validationErrChan:
@@ -57,20 +88,37 @@ func logValidationErrors(ctx context.Context, validationErrChan chan *proxy.Vali
 				return
 			}
 
-			logrus.WithField("validation_errors", validationErr.String()).Errorf("error validating message")
+			logrus.WithField("validation_errors", validationErr.String()).Debug("error validating message")
+			entry := noopLogger.WithFields(logrus.Fields{
+				"channel":           validationErr.Msg.Context.Channel,
+				"key":               string(validationErr.Msg.Key),
+				"headers":           validationErr.Msg.Headers,
+				"validation_errors": validationErr.Result.Errors(),
+			}).WithTime(time.Now())
+			entry.Level = logrus.InfoLevel
+
+			txt, _ := f.Format(entry)
+			if err := m.Broadcast(txt); err != nil {
+				logrus.WithError(err).Error("error broadcasting message to all ws sessions")
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func handleInterruptions(cancel context.CancelFunc) {
+func handleInterruptions(cancel context.CancelFunc, funcs ...func() error) {
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		s := <-c
 		logrus.WithField("signal", s).Info("Stopping AsyncAPI Event-Gateway...")
 		cancel()
+		for _, f := range funcs {
+			if err := f(); err != nil {
+				logrus.WithError(err).Error("error shutting down")
+			}
+		}
 		time.Sleep(time.Second)
 		os.Exit(0)
 	}()

--- a/proxy/validation.go
+++ b/proxy/validation.go
@@ -39,7 +39,7 @@ func (v ValidationError) String() string {
 		errs[i] = err.String()
 	}
 
-	return strings.Join(errs, " | ")
+	return fmt.Sprintf("Errors validating message on channel %q: %s", v.Msg.Context.Channel, strings.Join(errs, " | "))
 }
 
 // ValidationErrorNotifier notifies whenever a ValidationError happens.

--- a/proxy/validation_test.go
+++ b/proxy/validation_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestValidationError_String(t *testing.T) {
-	validationErr := generateTestValidationError(nil)
-	assert.Equal(t, "AnIntegerField: Invalid type. Expected: integer, given: string | AStringField: Invalid type. Expected: string, given: integer", validationErr.String())
+	expectedMessage := generateTestMessage()
+	validationErr := generateTestValidationError(expectedMessage)
+	assert.Equal(t, `Errors validating message on channel "test": AnIntegerField: Invalid type. Expected: integer, given: string | AStringField: Invalid type. Expected: string, given: integer`, validationErr.String())
 }
 
 func TestNotifyOnValidationError(t *testing.T) {


### PR DESCRIPTION
**Description**

This PR adds a new WS endpoint where people can connect to and see all validation errors of all messages flowing through the gateway.
It is an early version of what the endpoint could do. By now, it lists all validation errors from **all** messages. People can kinda differentiate messages by checking, for example, the headers.

Pending to add an AsyncAPI yaml file (next pr).

Another work I will like to do is a simple static HTML that connects to the WS and shows the messages.

In the near future, it could implement filtering (by header, topic, etc), but for today, this is more than ok. 

Demo:
![CleanShot 2021-07-30 at 16 13 58](https://user-images.githubusercontent.com/1083296/127666918-f80ea5c6-9b72-42c9-a185-b6099a1b3dda.gif)

**Related issue(s)**
https://github.com/asyncapi/event-gateway/issues/23