### PR TITLE
feat: encode ws messages to json so they become machine-readable

### DIFF
--- a/asyncapi/v2/validation_test.go
+++ b/asyncapi/v2/validation_test.go
@@ -103,7 +103,7 @@ func TestFromDocJsonSchemaMessageValidator(t *testing.T) {
 				assert.Nil(t, validationErr)
 			} else {
 				assert.NotNil(t, validationErr)
-				assert.False(t, validationErr.Result.Valid())
+				assert.NotEmpty(t, validationErr.Errors)
 			}
 		})
 	}

--- a/proxy/validation_test.go
+++ b/proxy/validation_test.go
@@ -2,22 +2,17 @@ package proxy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xeipuuv/gojsonschema"
 )
 
-func TestValidationError_String(t *testing.T) {
-	expectedMessage := generateTestMessage()
-	validationErr := generateTestValidationError(expectedMessage)
-	assert.Equal(t, `Errors validating message on channel "test": AnIntegerField: Invalid type. Expected: integer, given: string | AStringField: Invalid type. Expected: string, given: integer`, validationErr.String())
-}
-
 func TestNotifyOnValidationError(t *testing.T) {
 	expectedMessage := generateTestMessage()
 	validator := func(msg *Message) (*ValidationError, error) {
 		assert.Equal(t, expectedMessage, msg)
-		return generateTestValidationError(msg), nil
+		return NewValidationError(msg, time.Now()), nil
 	}
 
 	var notified bool
@@ -28,7 +23,7 @@ func TestNotifyOnValidationError(t *testing.T) {
 
 	validationErr, err := NotifyOnValidationError(validator, notifier)(expectedMessage)
 	assert.NoError(t, err)
-	assert.False(t, validationErr.Result.Valid())
+	assert.NotEmpty(t, validationErr.Errors)
 	assert.True(t, notified)
 }
 
@@ -37,36 +32,6 @@ func generateTestMessage() *Message {
 		Context: MessageContext{Channel: "test"},
 		Value:   []byte(`Hello World!`),
 	}
-}
-
-func generateTestValidationError(msg *Message) *ValidationError {
-	validationErr := &ValidationError{
-		Msg:    msg,
-		Result: &gojsonschema.Result{},
-	}
-
-	addTestErrors(validationErr)
-	return validationErr
-}
-
-func addTestErrors(validationErr *ValidationError) {
-	badTypeErr := &gojsonschema.InvalidTypeError{}
-	badTypeErr.SetContext(gojsonschema.NewJsonContext("AnIntegerField", nil))
-	badTypeErr.SetDetails(gojsonschema.ErrorDetails{
-		"expected": gojsonschema.TYPE_INTEGER,
-		"given":    gojsonschema.TYPE_STRING,
-	})
-	badTypeErr.SetDescriptionFormat(gojsonschema.Locale.InvalidType())
-	validationErr.Result.AddError(badTypeErr, badTypeErr.Details())
-
-	badTypeErr2 := &gojsonschema.InvalidTypeError{}
-	badTypeErr2.SetContext(gojsonschema.NewJsonContext("AStringField", nil))
-	badTypeErr2.SetDetails(gojsonschema.ErrorDetails{
-		"expected": gojsonschema.TYPE_STRING,
-		"given":    gojsonschema.TYPE_INTEGER,
-	})
-	badTypeErr2.SetDescriptionFormat(gojsonschema.Locale.InvalidType())
-	validationErr.Result.AddError(badTypeErr2, badTypeErr2.Details())
 }
 
 func TestJsonSchemaMessageValidator(t *testing.T) {
@@ -122,7 +87,7 @@ func TestJsonSchemaMessageValidator(t *testing.T) {
 				assert.Nil(t, validationErr)
 			} else {
 				assert.NotNil(t, validationErr)
-				assert.False(t, validationErr.Result.Valid())
+				assert.NotEmpty(t, validationErr.Errors)
 			}
 		})
 	}

--- a/proxy/validation_test.go
+++ b/proxy/validation_test.go
@@ -12,7 +12,7 @@ func TestNotifyOnValidationError(t *testing.T) {
 	expectedMessage := generateTestMessage()
 	validator := func(msg *Message) (*ValidationError, error) {
 		assert.Equal(t, expectedMessage, msg)
-		return NewValidationError(msg, time.Now()), nil
+		return NewValidationError(msg, time.Now(), "This is a validation error"), nil
 	}
 
 	var notified bool


### PR DESCRIPTION
**Description**

This PR changes the way validation errors are encoded and then sent to the WS connection. In particular, it encodes each WS message to JSON so it can become machine-readable. This is useful for automating  end-to-end tests on real infrastructure.

An example of an encoded WS message (formatted):
```json
{
    "ts": "2021-08-16T12:36:12.025941+02:00",
    "msg": {
        "context": {
            "channel": "demo"
        },
        "key": "c21veWEtd2FzLWhlcmU=",
        "value": "eyJjb21tYW5kIjogMX0="
    },
    "errors": [
        "command: Invalid type. Expected: string, given: integer"
    ]
}
```

**Related issue(s)**
https://github.com/asyncapi/event-gateway/issues/23