### PR TITLE
feat: default dynamic listener ip set to 0.0.0.0

### DIFF
--- a/kafka/proxy.go
+++ b/kafka/proxy.go
@@ -46,6 +46,9 @@ func NewProxy(c *ProxyConfig) (proxy.Proxy, error) {
 	// Yeah, not a good practice at all but I guess it's fine for now.
 	kafkaproxy.ActualDefaultRequestHandler.RequestKeyHandlers.Set(protocol.RequestAPIKeyProduce, NewProduceRequestHandler(c.MessageHandlers...))
 
+	// Setting some defaults.
+	_ = server.Server.Flags().Set("default-listener-ip", "0.0.0.0") // Binding to all local network interfaces. Needed for external calls.
+
 	if c.BrokersMapping == nil {
 		return nil, errors.New("Brokers mapping is required")
 	}


### PR DESCRIPTION
**Description**

Context: Most of the times, kafka brokers don't have an static IP. We just have one DSN such as `kafka.myserver.org` which resolves to a broker (or load balancer) which then discovers all the broker IPs at that moment, sending that info back to the Kafka client (this is standard Kafka protocol). 
Those brokers will need to map to a local port so they can be accessed by Kafka clients. Those ports are called Dynamic listeners in our app (and in https://github.com/grepplabs/kafka-proxy).

Those ports are opened binding to localhost, however `120.0.0.1` is used as binding IP, meaning `127.0.0.1` only binds to local network interface, and won't be accessible from outside the machine. Meanwhile `0.0.0.0` binds to all network interfaces allowing to do calls to those ports from anywhere (up to your firewall, security group, etc on top of it).

Unless there is a strong reason for binding to `127.0.0.1` (I opened up an issue here https://github.com/grepplabs/kafka-proxy/issues/89 ), `0.0.0.0` by default will allow making external calls to the dynamic listeners, meaning they will be accessible from outside the machine. 

This might change if such strong reason is provided in https://github.com/grepplabs/kafka-proxy, but for now, binding to `0.0.0.0` will help a lot to avoid barriers when configuring the proxy, specially the first time. 

There is always a way to change that value to whatever the user wants, by setting the extra flag `default-listener-ip=<ip-here>` in `EVENTGATEWAY_KAFKA_PROXY_EXTRA_FLAGS` env var.