### PR TITLE
feat(config): remove support for configuring kafka broker from env vars

### DIFF
--- a/config/kafka_test.go
+++ b/config/kafka_test.go
@@ -18,7 +18,7 @@ func TestKafkaProxy_ProxyConfig(t *testing.T) {
 		expectedErr         error
 	}{
 		{
-			name: "Valid config. Only one broker from doc",
+			name: "Valid config. Only one broker",
 			config: &KafkaProxy{
 				BrokerFromServer: "test",
 				// Also testing extra flags.
@@ -33,7 +33,7 @@ func TestKafkaProxy_ProxyConfig(t *testing.T) {
 			doc: []byte(`testdata/simple-kafka.yaml`),
 		},
 		{
-			name: "Valid config. Only one broker from doc + enable message validation",
+			name: "Valid config. Only one broker + enable message validation",
 			config: &KafkaProxy{
 				BrokerFromServer: "test",
 				MessageValidation: MessageValidation{
@@ -48,7 +48,7 @@ func TestKafkaProxy_ProxyConfig(t *testing.T) {
 			doc: []byte(`testdata/simple-kafka.yaml`),
 		},
 		{
-			name: "Valid config. Only one broker + Override listener port from doc",
+			name: "Valid config. Only one broker + Override listener port",
 			config: &KafkaProxy{
 				BrokerFromServer: "test",
 			},
@@ -60,7 +60,7 @@ func TestKafkaProxy_ProxyConfig(t *testing.T) {
 			doc: []byte(`testdata/override-port-kafka.yaml`),
 		},
 		{
-			name:   "Valid config. All brokers + Override listener port from doc",
+			name:   "Valid config. All brokers + Override listener port",
 			config: &KafkaProxy{},
 			expectedProxyConfig: func(t *testing.T, c *kafka.ProxyConfig) *kafka.ProxyConfig {
 				return &kafka.ProxyConfig{
@@ -81,47 +81,10 @@ func TestKafkaProxy_ProxyConfig(t *testing.T) {
 			doc: []byte(`testdata/dial-mapping-kafka.yaml`),
 		},
 		{
-			name: "Valid config. Only broker mapping",
-			config: &KafkaProxy{
-				BrokersMapping: pipeSeparatedValues{Values: []string{"broker.mybrokers.org:9092,:9092"}},
-			},
-			expectedProxyConfig: func(_ *testing.T, _ *kafka.ProxyConfig) *kafka.ProxyConfig {
-				return &kafka.ProxyConfig{
-					BrokersMapping: []string{"broker.mybrokers.org:9092,:9092"},
-				}
-			},
-		},
-		{
-			name: "Valid config. Broker mapping + Dial mapping",
-			config: &KafkaProxy{
-				BrokersMapping:     pipeSeparatedValues{Values: []string{"broker.mybrokers.org:9092,:9092"}},
-				BrokersDialMapping: pipeSeparatedValues{Values: []string{"broker.mybrokers.org:9092,192.168.1.10:9092"}},
-			},
-			expectedProxyConfig: func(_ *testing.T, _ *kafka.ProxyConfig) *kafka.ProxyConfig {
-				return &kafka.ProxyConfig{
-					BrokersMapping:     []string{"broker.mybrokers.org:9092,:9092"},
-					DialAddressMapping: []string{"broker.mybrokers.org:9092,192.168.1.10:9092"},
-				}
-			},
-		},
-		{
-			name:        "Invalid config. No broker mapping",
+			name:        "Invalid config. Both broker and proxy are the same",
 			config:      &KafkaProxy{},
-			expectedErr: errors.New("either AsyncAPIDoc or KafkaProxyBrokersMapping config should be provided"),
-		},
-		{
-			name: "Invalid config. Both broker and proxy can't listen to the same port within same host",
-			config: &KafkaProxy{
-				BrokersMapping: pipeSeparatedValues{Values: []string{"localhost:9092,:9092"}},
-			},
 			expectedErr: errors.New("broker and proxy can't listen to the same port on the same host. Broker is already listening at localhost:9092. Please configure a different listener port"),
-		},
-		{
-			name: "Invalid config. Both broker and proxy are the same",
-			config: &KafkaProxy{
-				BrokersMapping: pipeSeparatedValues{Values: []string{"broker.mybrokers.org:9092,broker.mybrokers.org:9092"}},
-			},
-			expectedErr: errors.New("broker and proxy can't listen to the same port on the same host. Broker is already listening at broker.mybrokers.org:9092. Please configure a different listener port"),
+			doc:         []byte(`testdata/invalid-same-address.yaml`),
 		},
 	}
 	for _, test := range tests {

--- a/config/testdata/invalid-same-address.yaml
+++ b/config/testdata/invalid-same-address.yaml
@@ -1,0 +1,22 @@
+asyncapi: '2.0.0'
+info:
+  title: Test
+  version: '1.0.0'
+servers:
+  test:
+    url: localhost:9092
+    protocol: kafka
+    x-eventgateway-listener: localhost:9092
+channels:
+  events:
+    publish:
+      operationId: onEvent
+      message:
+        name: event
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the event.

--- a/docs/config/kafka.md
+++ b/docs/config/kafka.md
@@ -4,16 +4,12 @@
 - A [Kafka](https://kafka.apache.org) Cluster visible to AsyncAPI Event-Gateway.
 
 ## Configuration
-The Kafka proxy can be configured (mostly) by reading config from `servers` on an AsyncAPI document.  
-However, some advanced configuration is only available through environment variables.
+The Kafka proxy is mostly configured by setting some properties on the `server` object.
 
-### From AsyncAPI doc
-By reading config from `servers`, the Kafka proxy is configured by default as it follows:
-
-- Uses each server `url` field as a new remote broker URL, using the same remote broker port as matching local port.
-  - In case `EVENTGATEWAY_KAFKA_PROXY_BROKER_FROM_SERVER` environment variable is set, only that specific server is configured.
-  - Local port can also be specified via `x-eventgateway-listener`, for example: ` x-eventgateway-listener: 28002`.
-- In case `x-eventgateway-dial-mapping` extension is present, is used in the same form as the `EVENTGATEWAY_KAFKA_PROXY_BROKERS_DIAL_MAPPING` environment variable.
+| Server property             | Type   | Description                                                                                                                                                                                                                                                                 | Default                        | Required | examples                                                                                                                                      |
+|-----------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| x-eventgateway-listener     | string | Configure the mapping between remote broker address (the address set in the broker server `URL` field) and desired local address. Format is `remotehost:remoteport,localhost:localport`. Multiple values can be configured by using pipe separation (`\|`)                  | `0.0.0.0:<remote-server-port>` | No       | `test.mykafkacluster.org:8092,localhost:28002`, `test.mykafkacluster.org:8092,localhost:28002\|test2.mykafkacluster.org:8092,localhost:28003` |
+| x-eventgateway-dial-mapping | string | Configure the mapping between published remote broker address and the address the proxy will use when forwarding requests. Format is `local_advertised_host:local_advertised_port,remotehost:remoteport`. Multiple values can be configured by using pipe separation (`\|`) | -                              | No       | `0.0.0.0:8092,test.myeventgateway.org:8092`, `0.0.0.0:8092,test.myeventgateway.org:8092,\|0.0.0.0:8093,test.myeventgateway.org:8093`          |
 
 #### Example
 ```yaml
@@ -22,16 +18,16 @@ servers:
   test:
     url: broker.mybrokers.org:9092
     protocol: kafka
-    x-eventgateway-listener: 28002 # optional. 9092 will be used instead if missing.
+    x-eventgateway-listener: 28002 # optional. 0.0.0.0:9092 will be used instead if missing.
     x-eventgateway-dial-mapping: '0.0.0.0:28002,test.myeventgateway.org:28002' # optional. 
 # ...
 ```
 
-### From environment variables
-| Environment variable                                | Type    | Description                                                                                                                                                                                                                                          | Default | Required                          | examples                                                                                                                                                                                                     |
-| --------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| EVENTGATEWAY_KAFKA_PROXY_BROKER_FROM_SERVER         | string  | When configuring from an AsyncAPI doc, this allows the user to only configure one server instead of all                                                                                                                                              | -       | No                                | `name-of-server1`, `server-test`                                                                                                                                                                             |
-| EVENTGATEWAY_KAFKA_PROXY_BROKERS_MAPPING            | string  | Configure the mapping between remote broker address (the address published by the broker) and desired local address. Format is `remotehost:remoteport,localhost:localport`. Multiple values can be configured by using pipe separation (`\|`)        | -       | Yes when no AsyncAPI doc provided | `test.mykafkacluster.org:8092,localhost:28002`, `test.mykafkacluster.org:8092,localhost:28002\|test2.mykafkacluster.org:8092,localhost:28003`                                                                 |
-| EVENTGATEWAY_KAFKA_PROXY_BROKERS_DIAL_MAPPING       | string  | Configure the mapping between published remote broker address and the address the proxy will use when forwarding requests. Format is `local_advertised_host:local_advertised_port,remotehost:remoteport`. Multiple values can be configured by using pipe separation (`\|`)  | -       | No                                | `0.0.0.0:8092,test.myeventgateway.org:8092`, `0.0.0.0:8092,test.myeventgateway.org:8092,\|0.0.0.0:8093,test.myeventgateway.org:8093` |
-| EVENTGATEWAY_KAFKA_PROXY_MESSAGE_VALIDATION_ENABLED | boolean | Enable or disable validation of Kafka messages                                                                                                                                                                                                       | `true`  | No                                | `true`, `false`                                                                                                                                                                                              |
-| EVENTGATEWAY_KAFKA_PROXY_EXTRA_FLAGS                | string  | Advanced configuration. Configure any flag from [here](https://github.com/grepplabs/kafka-proxy/blob/4f3b89fbaecb3eb82426f5dcff5f76188ea9a9dc/cmd/kafka-proxy/server.go#L85-L195). Multiple values can be configured by using pipe separation (`\|`) | -       | No                                | `tls-enable=true\|tls-client-cert-file=/opt/var/service.cert\|tls-client-key-file=/opt/var/service.key`                                                                                                        |
+## Advanced configuration
+Some advanced configuration is only available through environment variables.
+
+| Environment variable                        | Type   | Description                                                                    | Default | Required | examples                         |
+|---------------------------------------------|--------|--------------------------------------------------------------------------------|---------|----------|----------------------------------|
+| EVENTGATEWAY_KAFKA_PROXY_BROKER_FROM_SERVER | string | When set, only the specified server will be considered instead of all servers. | -       | No       | `name-of-server1`, `server-test` |
+| EVENTGATEWAY_KAFKA_PROXY_MESSAGE_VALIDATION_ENABLED | boolean | Enable or disable validation of Kafka messages                                                                                                                                                                                                       | `true`  | No       | `true`, `false`                                                                                         |
+| EVENTGATEWAY_KAFKA_PROXY_EXTRA_FLAGS                | string  | Advanced configuration. Configure any flag from [here](https://github.com/grepplabs/kafka-proxy/blob/4f3b89fbaecb3eb82426f5dcff5f76188ea9a9dc/cmd/kafka-proxy/server.go#L85-L195). Multiple values can be configured by using pipe separation (`\|`) | -       | No       | `tls-enable=true\|tls-client-cert-file=/opt/var/service.cert\|tls-client-key-file=/opt/var/service.key` |

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -31,10 +31,10 @@ func WithMessageHandlers(messageHandlers ...MessageHandler) Option {
 	}
 }
 
-// WithDebug enables debug.
-func WithDebug() Option {
+// WithDebug enables/disables debug.
+func WithDebug(enabled bool) Option {
 	return func(c *ProxyConfig) error {
-		c.Debug = true
+		c.Debug = enabled
 		return nil
 	}
 }


### PR DESCRIPTION
**Description**

Fixes https://github.com/asyncapi/event-gateway/issues/50.

This PR drops the option to configure Kafka broker mappings from env vars. Instead, it forces the user to use AsyncAPI, which becomes the main config source from now on.

**Related issue(s)**
https://github.com/asyncapi/event-gateway/issues/50