### PR TITLE
ci: remove support for Go 1.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
         go:
           - '1.17'
           - '1.16'
-          - '1.15'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
**Description**

Go 1.16 deprecates [ioutil](https://pkg.go.dev/io/ioutil) package. See https://golang.org/doc/go1.16#ioutil.
Event-Gateway code is already considering such deprecation and is not compatible with Go 1.15 anymore.

This PR removes support for Go 1.15 on CI.

**Related issue(s)**
https://github.com/asyncapi/event-gateway/runs/4021112037?check_suite_focus=true

![CleanShot 2021-10-27 at 13 00 37](https://user-images.githubusercontent.com/1083296/139053446-c8b31a9b-8aee-4bb0-97fd-12d8d9d6265d.png)
