### PR TITLE
fix: set pullPolicy to Always since we are under development phase

### DIFF
--- a/deployments/k8s/asyncapi-event-gateway/values.yaml
+++ b/deployments/k8s/asyncapi-event-gateway/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: asyncapi/event-gateway
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: "latest"
 
 imagePullSecrets: []


### PR DESCRIPTION
**Description**

This PR sets the docker image pull policy to `Always` on our K8s helm charts so on every deploy we update the Docker image.

This is useful since we are under development, so changes should be quickly propagated and tested. 
Once we fix https://github.com/asyncapi/event-gateway/issues/86, we could move that change to the `event-gateway-demo` chart instead. 