### PR TITLE
fix: set event-gateway-demo domain extension to .com

### DIFF
--- a/deployments/k8s/event-gateway-demo/event-gateway-demo.asyncapi.yaml
+++ b/deployments/k8s/event-gateway-demo/event-gateway-demo.asyncapi.yaml
@@ -6,11 +6,11 @@ info:
 defaultContentType: application/json
 servers:
   asyncapi-event-gateway-demo:
-    url: 'event-gateway-demo.asyncapi.org:20472'
+    url: 'event-gateway-demo.asyncapi.com:20472'
     protocol: kafka
     description: AsyncAPI [Event-Gateway](https://github.com/asyncapi/event-gateway) demo Kafka proxy. Expected messages are based on a small portion of the [StreetLights tutorial](https://bit.ly/asyncapi).
   asyncapi-event-gateway-demo-validation:
-    url: 'event-gateway-demo.asyncapi.org:5000/ws'
+    url: 'event-gateway-demo.asyncapi.com:5000/ws'
     protocol: ws
     description: AsyncAPI [Event-Gateway](https://github.com/asyncapi/event-gateway) demo. Subscribe for Kafka proxy message validation errors.
   asyncapi-kafka-test:

--- a/deployments/k8s/event-gateway-demo/templates/NOTES.txt
+++ b/deployments/k8s/event-gateway-demo/templates/NOTES.txt
@@ -2,7 +2,7 @@
   If this is the first time you create this app, or you changed the service.type value to LoadBalancer, you should redeploy it by setting the recently created Load Balancer IP as proxy ip.
 
   Please run:
-  export LB_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath={.status.loadBalancer.ingress[0].ip} service {{ include "asyncapi-event-gateway.fullname" . }})
+  export LB_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath={.status.loadBalancer.ingress[0].ip} service {{ .Chart.Name }}-asyncapi-event-gateway)
 
-  Then redeploy your chart and include the following config: --set asyncapi-event-gateway.env.EVENTGATEWAY_KAFKA_PROXY_ADDRESS=$LB_IP
+  Then redeploy your chart (by using `upgrade` instead of `install`) and include the following config: --set asyncapi-event-gateway.env.EVENTGATEWAY_KAFKA_PROXY_ADDRESS=$LB_IP
 {{ end }}


### PR DESCRIPTION
**Description**

We are using `.com` instead of `.org` on all our services from time ago (for SEO purpose) so I'm fixing that right now. Also the event-gateway-demo is deployed and the DNS records are only added to the `.com`.

I'm taking this opportunity to fix the helper message from the chart so it prints the right service name.