### PR TITLE
ci: allow setting extra deployment pod labels in Helm chart

### DIFF
--- a/deployments/k8s/asyncapi-event-gateway/templates/deployment.yaml
+++ b/deployments/k8s/asyncapi-event-gateway/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       {{- end }}
       labels:
         {{- include "asyncapi-event-gateway.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.deploymentExtraLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deployments/k8s/asyncapi-event-gateway/values.yaml
+++ b/deployments/k8s/asyncapi-event-gateway/values.yaml
@@ -101,6 +101,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+deploymentExtraLabels: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
**Description**

This PR allow users to set extra labels on the Deployment pods. Useful for custom labels or to force a Docker image pull when executing `helm upgrade` command when the Docker image tag is set to `latest` and there is no change in the chart.
In this case, users can add an extra label such as `--set asyncapi-event-gateway.deploymentExtraLabels.date=$(date +%s)` so Helm recreates the pod.

This is not yet documented but it will be in a next iteration.