### PR TITLE
fix: skip message when invalid JSON

### DIFF
--- a/message/handler/validate.go
+++ b/message/handler/validate.go
@@ -19,7 +19,8 @@ func ValidateMessage(validator message.Validator, failWhenInvalid bool) watermil
 	return func(msg *watermillmessage.Message) ([]*watermillmessage.Message, error) {
 		validationErr, err := validator(msg)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).Error("failed to validate message. Skipping message...")
+			return nil, nil
 		}
 
 		if validationErr != nil {


### PR DESCRIPTION
**Description**

This PR fixes an infinite loop in the message pipeline when a message payload is not a valid JSON. As the message handler was returning an error, this was telling watermill to retry and retry. Here is a portion of the output log lines:

```bash
ERRO[2021-12-16T12:42:55+01:00] Handler returned error                        error="error validating JSON Schema for message event-gateway-demo: invalid character 'b' looking fo
r beginning of value"
ERRO[2021-12-16T12:42:55+01:00] failed to validate message. Skipping message...  error="error validating JSON Schema for message event-gateway-demo: invalid character 'b' looking
 for beginning of value"
ERRO[2021-12-16T12:42:55+01:00] Handler returned error                        error="error validating JSON Schema for message event-gateway-demo: invalid character 'b' looking fo
r beginning of value"
...
```

This code change skips returning the error and it just logs a new error line. In the future, we could configure those messages and errors to be pushed to another queue, etc.