### PR TITLE
docs: fix links in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The Minimum required version of Go is set in [go.mod](go.mod) file.
 2. Run `make build`. The binary will be placed at `bin/out/event-gateway`.
 
 ### Configuration
-Please refer to [/docs/config](/docs/config).
+Please refer to [config reference](/docs/config/README.md).
 
 ## Contributing
 Read [CONTRIBUTING](https://github.com/asyncapi/.github/blob/master/CONTRIBUTING.md) guide.


### PR DESCRIPTION
#### Description
this PR is supposed to fix all the [broken links](https://github.com/asyncapi/event-gateway/runs/6143316805?check_suite_focus=true) in markdown files across the repo.